### PR TITLE
Readme heading styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-#Animated SVG Climacons v. 0.2
+# Animated SVG Climacons v. 0.2
 Adam Whitcroft's Climacons as SVGs animated with CSS by Noah Blon.
 
 Visit the [Climacons](http://adamwhitcroft.com/climacons/) website to download the original icons.
 
-##To Do
+## To Do
 
 * Finish the rest of the icons
 * Optimize all icons.
@@ -13,5 +13,5 @@ Visit the [Climacons](http://adamwhitcroft.com/climacons/) website to download t
 * Explore animation w/ GSAP, Raphael, and/or SMIL.
 * Write user guide & provide examples.
 
-##License
+## License
 You are free to use any of the Climacons Animated Icons (the "icons") in any personal or commercial work without obligation of payment (monetary or otherwise) or attribution, however a credit for the work would be appreciated. <strong>Do not</strong> redistribute or sell and <strong>do not</strong> claim creative credit. Intellectual property rights are not transferred with the download of the icons.


### PR DESCRIPTION
Github changed their markdown rendering a while ago. It new requires a space between `#` and the rest of a section header. Came across your repository and filing this PR to make the readme look like it used to